### PR TITLE
Fix issue that ro.telephony.default_network can't be read per slot

### DIFF
--- a/prebuilts/api/28.0/public/property_contexts
+++ b/prebuilts/api/28.0/public/property_contexts
@@ -115,7 +115,7 @@ ro.sf.lcd_density u:object_r:exported3_default_prop:s0 exact int
 ro.storage_manager.enabled u:object_r:exported3_default_prop:s0 exact bool
 ro.telephony.call_ring.multiple u:object_r:exported3_default_prop:s0 exact bool
 ro.telephony.default_cdma_sub u:object_r:exported3_default_prop:s0 exact int
-ro.telephony.default_network u:object_r:exported3_default_prop:s0 exact int
+ro.telephony.default_network u:object_r:exported3_default_prop:s0 exact string
 ro.url.legal u:object_r:exported3_default_prop:s0 exact string
 ro.url.legal.android_privacy u:object_r:exported3_default_prop:s0 exact string
 ro.vendor.build.security_patch u:object_r:vendor_security_patch_level_prop:s0 exact string

--- a/public/property_contexts
+++ b/public/property_contexts
@@ -115,7 +115,7 @@ ro.sf.lcd_density u:object_r:exported3_default_prop:s0 exact int
 ro.storage_manager.enabled u:object_r:exported3_default_prop:s0 exact bool
 ro.telephony.call_ring.multiple u:object_r:exported3_default_prop:s0 exact bool
 ro.telephony.default_cdma_sub u:object_r:exported3_default_prop:s0 exact int
-ro.telephony.default_network u:object_r:exported3_default_prop:s0 exact int
+ro.telephony.default_network u:object_r:exported3_default_prop:s0 exact string
 ro.url.legal u:object_r:exported3_default_prop:s0 exact string
 ro.url.legal.android_privacy u:object_r:exported3_default_prop:s0 exact string
 ro.vendor.build.security_patch u:object_r:vendor_security_patch_level_prop:s0 exact string


### PR DESCRIPTION
"ro.telephony.default_network" can define as comma-separated Sting per
slot for multi SIM device. However, it cannot be read correctly due to
it defined as Int in property_contexts file.

Bug: 110626665
Test: manual - Checked the ro.telephony.default_network can be read per
slot for multi SIM device.

(cherry picked from commit bbb439e76a278a9e31c95151303d7ffe69812bb6)

Author: Avinash Nalluri <anallu@codeaurora.org>
Date:   Fri Jul 27 12:15:12 2018 -0700

    Fix issue that ro.telephony.default_network can't be read per slot

    "ro.telephony.default_network" can define as comma-separated Sting per
    slot for multi SIM device. However, it cannot be read correctly due to
    it defined as Int in property_contexts file.

    Bug: 110626665
    CRs-Fixed: 2259245
    Change-Id: Idae179f9c746e055bc43acebc0ffe28e5bd92b29

Change-Id: I900620e46c819c14bf339751f00a1db1473fd45f