### PR TITLE
sepolicy: Grant mediaextractor access to files over all sdcard fs types

### DIFF
--- a/public/mediaextractor.te
+++ b/public/mediaextractor.te
@@ -23,7 +23,7 @@ allow mediaextractor proc_meminfo:file r_file_perms;
 crash_dump_fallback(mediaextractor)
 
 # allow mediaextractor read permissions for file sources
-allow mediaextractor sdcardfs:file { getattr read };
+allow mediaextractor sdcard_type:file { getattr read };
 allow mediaextractor media_rw_data_file:file { getattr read };
 allow mediaextractor app_data_file:file { getattr read };
 


### PR DESCRIPTION
 * Account for all possible sdcard-related filesystem types and not only
   sdcardfs:

   public/file.te:108:type fuse, sdcard_type, fs_type, mlstrustedobject;
   public/file.te:109:type sdcardfs, sdcard_type, fs_type, mlstrustedobject;
   public/file.te:110:type sdcard_posix, sdcard_type, fs_type, mlstrustedobject;
   public/file.te:111:type vfat, sdcard_type, fs_type, mlstrustedobject;
   public/file.te:112:type exfat, sdcard_type, fs_type, mlstrustedobject;

Change-Id: Ic508397bf4ca66a002ada33ac3f600c17b8a1a10