### PR TITLE
Allow mediaserver to read device directories

### DIFF
--- a/public/mediaserver.te
+++ b/public/mediaserver.te
@@ -136,6 +136,11 @@ allow mediaserver media_rw_data_file:file create_file_perms;
 # Access to media in /data/preloads
 allow mediaserver preloads_media_file:file { getattr read ioctl };
 
+ifelse(target_has_legacy_camera_hal1, `true',
+  allow mediaserver device:dir r_dir_perms;
+,
+)
+
 allow mediaserver ion_device:chr_file r_file_perms;
 allow mediaserver hal_graphics_allocator:fd use;
 allow mediaserver hal_graphics_composer:fd use;


### PR DESCRIPTION
* Needed both to allow ExternalCameraProvider to probe for
  video devices as well as allow access/recognition of
  external storage

* avc: denied { read } for name="/" dev="tmpfs" ino=6954
  scontext=u:r:mediaserver:s0 tcontext=u:object_r:device:s0
  tclass=dir permissive=1
* avc: denied { open } for name="/" dev="tmpfs" ino=6954
  scontext=u:r:mediaserver:s0 tcontext=u:object_r:device:s0
  tclass=dir permissive=1

Change-Id: I32540b8ec48ff61568094ec87d1bad64570a8e55