### PR TITLE
Allow init to write to /proc/cpu/alignment

### DIFF
--- a/private/genfs_contexts
+++ b/private/genfs_contexts
@@ -20,6 +20,7 @@ genfscon proc /mounts u:object_r:proc_mounts:s0
 genfscon proc /net u:object_r:proc_net:s0
 genfscon proc /net/xt_qtaguid/ctrl u:object_r:qtaguid_proc:s0
 genfscon proc /net/xt_qtaguid/ u:object_r:proc_qtaguid_stat:s0
+genfscon proc /cpu/alignment u:object_r:proc_cpu_alignment:s0
 genfscon proc /cpuinfo u:object_r:proc_cpuinfo:s0
 genfscon proc /pagetypeinfo u:object_r:proc_pagetypeinfo:s0
 genfscon proc /softirqs u:object_r:proc_timer:s0

--- a/public/file.te
+++ b/public/file.te
@@ -20,6 +20,7 @@ type proc_abi, fs_type, proc_type;
 type proc_asound, fs_type, proc_type;
 type proc_buddyinfo, fs_type, proc_type;
 type proc_cmdline, fs_type, proc_type;
+type proc_cpu_alignment, fs_type, proc_type;
 type proc_cpuinfo, fs_type, proc_type;
 type proc_dirty, fs_type, proc_type;
 type proc_diskstats, fs_type, proc_type;

--- a/public/init.te
+++ b/public/init.te
@@ -293,6 +293,7 @@ allow init {
 
 allow init {
   proc_abi
+  proc_cpu_alignment
   proc_dirty
   proc_hostname
   proc_hung_task


### PR DESCRIPTION
* AOSP init.rc attempts to write to /proc/cpu/alignment, but
  following 84e181bc, general access to procfs nodes is prohibited.
* Add an appropriate type, genfscon, and allow to permit this
  action.

Change-Id: I31ad8eaa6ebb6dd57d1b9c4395cb22cdd0d7b3d3