### PR TITLE
Allow init to chmod/chown /proc/slabinfo

### DIFF
--- a/private/genfs_contexts
+++ b/private/genfs_contexts
@@ -23,6 +23,7 @@ genfscon proc /net/xt_qtaguid/ u:object_r:proc_qtaguid_stat:s0
 genfscon proc /cpu/alignment u:object_r:proc_cpu_alignment:s0
 genfscon proc /cpuinfo u:object_r:proc_cpuinfo:s0
 genfscon proc /pagetypeinfo u:object_r:proc_pagetypeinfo:s0
+genfscon proc /slabinfo u:object_r:proc_slabinfo:s0
 genfscon proc /softirqs u:object_r:proc_timer:s0
 genfscon proc /stat u:object_r:proc_stat:s0
 genfscon proc /swaps u:object_r:proc_swaps:s0

--- a/public/file.te
+++ b/public/file.te
@@ -47,6 +47,7 @@ type proc_pid_max, fs_type, proc_type;
 type proc_pipe_conf, fs_type, proc_type;
 type proc_random, fs_type, proc_type;
 type proc_sched, fs_type, proc_type;
+type proc_slabinfo, fs_type, proc_type;
 type proc_stat, fs_type, proc_type;
 type proc_swaps, fs_type, proc_type;
 type proc_sysrq, fs_type, proc_type;

--- a/public/init.te
+++ b/public/init.te
@@ -286,6 +286,7 @@ allow init {
   proc_last_kmsg
   proc_kmsg # Open /proc/kmsg for logd service.
   proc_meminfo
+  proc_slabinfo
   proc_stat # Read /proc/stat for bootchart.
   proc_uptime
   proc_version


### PR DESCRIPTION
* AOSP init.rc attempts to chmod and chown /proc/slabinfo, but
  following 84e181bc, general access to procfs nodes is prohibited.
* Add an appropriate type, genfscon, and allow to permit those
  actions.

Change-Id: I8659fb571b6ddb938640be42388a93f3b40fbe0a