### PR TITLE
Allow fsck_untrusted to getattr block_device

### DIFF
--- a/public/fsck_untrusted.te
+++ b/public/fsck_untrusted.te
@@ -9,7 +9,7 @@ allow fsck_untrusted vold:fd use;
 allow fsck_untrusted vold:fifo_file { read write getattr };
 
 # Run fsck on vold block devices
-allow fsck_untrusted block_device:dir search;
+allow fsck_untrusted block_device:dir { getattr search };
 allow fsck_untrusted vold_device:blk_file rw_file_perms;
 
 allow fsck_untrusted proc_mounts:file r_file_perms;


### PR DESCRIPTION
 * Noted upon conntecing usb_otg
 * avc: denied { getattr } for path="/dev/block" dev="tmpfs"
   ino=8466 scontext=u:r:fsck_untrusted:s0
   tcontext=u:object_r:block_device:s0 tclass=dir permissive=0

Change-Id: I0b95c3ee1b76f6bf0ecc030a628baab95e65861b