### PR TITLE
sepolicy: public: Exclude Recovery from system mount neverallow

### DIFF
--- a/public/domain.te
+++ b/public/domain.te
@@ -494,7 +494,7 @@ neverallow { domain -kernel with_asan(`-asan_extract') } { system_file vendor_fi
 
 # Don't allow mounting on top of /system files or directories
 neverallow * exec_type:dir_file_class_set mounton;
-neverallow { domain -init } { system_file vendor_file_type }:dir_file_class_set mounton;
+neverallow { domain -init userdebug_or_eng(`-recovery') } { system_file vendor_file_type }:dir_file_class_set mounton;
 
 # Nothing should be writing to files in the rootfs.
 neverallow { domain userdebug_or_eng(`-recovery') } rootfs:file { create write setattr relabelto append unlink link rename };


### PR DESCRIPTION
* This is needed to allow recovery to (re)mount /system.

Change-Id: I92ea22c12872f734bddbb47672eb1e9f36e33ba0