### PR TITLE
sepolicy: Fix building on MacOS

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -744,7 +744,7 @@ $(sepolicy.recovery.conf): $(call build_policy, $(sepolicy_build_files), \
 	$(transform-policy-to-conf)
 	$(hide) sed '/dontaudit/d' $@ > $@.dontaudit
 ifeq ($(SELINUX_IGNORE_NEVERALLOWS),true)
-	$(hide) sed -z 's/\n\s*neverallow[^;]*;/\n/g' $@ > $@.neverallow
+	$(hide) awk '/^ *neverallow/ { na=1; } /;$$/ { eob=1; } { if (na==0) { print; } if (eob==1) { na=0; } eob=0; }' $@ > $@.neverallow
 	$(hide) mv $@.neverallow $@
 endif
 


### PR DESCRIPTION
* The MacOS version of sed does not understand -z.
* Use awk to delete neverallow blocks instead.

Change-Id: I9c37a3af2a8d46a6a9292e7270696b0dec840445